### PR TITLE
hyein

### DIFF
--- a/assets/map.html
+++ b/assets/map.html
@@ -55,7 +55,11 @@
               return;
             }
             case 'panTo': {
-              map.panTo(payload.coords, payload.transitionOptions);
+              const zoom = map.getZoom();
+              const building = new naver.maps.LatLng(Number(payload.coords.lat), Number(payload.coords.lng));
+              const coords = map.getProjection().getDestinationCoord(building, 180, zoom>=13 ? 50:1500/zoom);
+
+              map.panTo(coords, payload.transitionOptions);
               return;
             }
             case 'updateMarkers': {

--- a/assets/map.html
+++ b/assets/map.html
@@ -110,9 +110,6 @@
               });
 
             }
-            case 'fitBounds': {
-                map.fitBounds(bounds);
-            }
             default:
               return;
           }
@@ -157,11 +154,16 @@
 
         var ping = setInterval(() => postAction('ping'), 66);
 
+        var min = {x: 127.35516786575319, y: 36.36317650086336},
+            max = {x: 127.37027406692503, y: 36.37634223427805};
+        var bounds = {north: max.y, east: max.x, south: min.y, west: min.x};
+
         var mapOptions = {
           center: { lat: 36.37334626411133, lng: 127.36397930294454 },
           zoom: 11,
           minZoom: 10,
           maxZoom: 14,
+          maxBounds: bounds,
         };
 
         var mapContainer = document.getElementById('map');
@@ -175,13 +177,8 @@
           postAction('click', { lat: coord.y, lng: coord.x });
         });
 
-        var min = {x: 127.35516786575319, y: 36.36317650086336},
-            max = {x: 127.37027406692503, y: 36.37634223427805};
-        var bounds = {north: max.y, east: max.x, south: min.y, west: min.x};
 
-        naver.maps.Event.addListener(map, "center_changed", function(center) {
-            postAction('centerChanged',center);
-        });
+
 
       })();
     </script>

--- a/components/NaverMap.js
+++ b/components/NaverMap.js
@@ -55,7 +55,7 @@ export default class NaverMap extends React.Component {
     this.updateMarkers();
     this.updateOptions();
     if (this.props.initialCoords) {
-      this.setCenter(this.props.initialCoords);
+      this.panTo(this.props.initialCoords);
     }
 
     if (this.props.onInit) {
@@ -141,7 +141,7 @@ export default class NaverMap extends React.Component {
       }
       case 'centerChanged' : {
         this.centerChanged(action.payload);
-        return
+        return;
       }
     }
   };

--- a/components/NaverMap.js
+++ b/components/NaverMap.js
@@ -103,15 +103,6 @@ export default class NaverMap extends React.Component {
     this.postAction('renderKAIST', {coords});
   };
 
-  centerChanged = (center) => {
-    const point = { type: 'Point', coordinates: [center._lng, center._lat] };
-    const kaist = require('../assets/geojson/KAIST.json').features[0].geometry;
-
-    if (!geojsonutil.pointInPolygon(point, kaist)) {
-      this.postAction('fitBounds');
-    }
-  };
-
   postAction = (type, payload) => {
     const action = { type, payload };
     this._webview.postMessage(JSON.stringify(action));
@@ -137,10 +128,6 @@ export default class NaverMap extends React.Component {
       }
       case 'renderKAIST': {
         this.renderKAIST();
-        return;
-      }
-      case 'centerChanged' : {
-        this.centerChanged(action.payload);
         return;
       }
     }


### PR DESCRIPTION
1. 사건 리스트 화면에서 사고 장소랑 카드랑 안겹치게 하기
2. 카이스트 외부로 맵 움직이면 fitbounds -> maxbounds 설정을 통해 화면 변동 없애기